### PR TITLE
Null selected on taggable throws exception.

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -246,7 +246,7 @@ module.exports = {
         ? this.options.filter(this.isNotSelected)
         : this.options
       options = this.$options.filters.filterBy(options, search)
-      if (this.taggable && search > 0 && !this.isExistingOption(search)) {
+      if (this.taggable && search.length > 0 && !this.isExistingOption(search)) {
         options.unshift({ isTag: true, label: search })
       }
       return options

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -241,12 +241,13 @@ module.exports = {
   },
   computed: {
     filteredOptions () {
+      let search = this.search ? this.search : ''
       var options = this.hideSelected
         ? this.options.filter(this.isNotSelected)
         : this.options
-      options = this.$options.filters.filterBy(options, this.search)
-      if (this.taggable && this.search.length > 0 && !this.isExistingOption(this.search)) {
-        options.unshift({ isTag: true, label: this.search })
+      options = this.$options.filters.filterBy(options, search)
+      if (this.taggable && search > 0 && !this.isExistingOption(search)) {
+        options.unshift({ isTag: true, label: search })
       }
       return options
     },


### PR DESCRIPTION
I'm getting an exception, that occurs when I pass down from parent `selected`, which is `null`.
Multiselect is taggable.
He're the exception:
```
app-cd1a3cff48.js:49506 [Vue warn]: Error when evaluating expression "
function () {
    var t = this.hideSelected ? this.options.filter(this.isNotSelected) : this.options;
    return t = this.$options.filters.filterBy(t, this.search), this.taggable && this.search.length > 0 && !this.isExistingOption(this.search) && t.unshift({ isTag: !0, label: this.search }), t;
        }
": TypeError: Cannot read property 'length' of null (found in component: <multiselect>)
```

Pull request fixes the issue.