### PR TITLE
Browserify es6 transform support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,14 @@
   "browserify": {
     "transform": [
       "vueify",
-      "babelify"
+      [
+        "babelify",
+        {
+          "presets": [
+            "es2015"
+          ]
+        }
+      ]
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Required to hint `browserify` that `*.vue` files should be babelified.
Without it, you get plain es6, which is not digestible by many browsers.