### PR TITLE
Fix 'getting-started' link in doc

### DIFF
--- a/docs/partials/_nav.jade
+++ b/docs/partials/_nav.jade
@@ -6,7 +6,7 @@ ul.list(
   :class="{ 'list--sticky': isNavSticky }"
 )
   li.list__heading Setup
-  +nav-element('Getting Started', '#getting-started')
+  +nav-element('Getting Started', 'getting-started')
 
   li.list__heading Examples
   +nav-element('Select (primitive)', 'select-primitive')


### PR DESCRIPTION
Right now, getting started point to http://monterail.github.io/vue-multiselect/##getting-started.
I just removed the `#`.