### PR TITLE
localSearch on 2.0

### DIFF
--- a/lib/multiselectMixin.js
+++ b/lib/multiselectMixin.js
@@ -10,6 +10,15 @@ module.exports = {
   },
   props: {
     /**
+     * Decide whether to filter the results based on search query.
+     * Useful for async filtering, where we search through more complex data.
+     * @type {Boolean}
+     */
+    localSearch: {
+      type: Boolean,
+      default: true
+    },
+    /**
      * Array of available options: Objects, Strings or Integers.
      * If array of objects, visible label will default to option.label.
      * If `labal` prop is passed, label will equal option['label']
@@ -176,9 +185,11 @@ module.exports = {
       let options = this.hideSelected
         ? this.options.filter(this.isNotSelected)
         : this.options
-      options = this.label
-        ? options.filter((option) => option[this.label].includes(this.search))
-        : options.filter((option) => option.includes(this.search))
+      if (this.localSearch) {
+        options = this.label
+          ? options.filter((option) => option[this.label].includes(this.search))
+          : options.filter((option) => option.includes(this.search))
+      }
       if (this.taggable && search.length && !this.isExistingOption(search)) {
         options.unshift({ isTag: true, label: search })
       }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "nightwatch": "^0.8.18",
     "node-sass": "^3.4.2",
     "ora": "^0.2.0",
+    "phantomjs-polyfill-includes": "0.0.1",
     "phantomjs-prebuilt": "^2.1.3",
     "sass-loader": "^3.2.0",
     "selenium-server": "^2.53.0",

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -10,6 +10,15 @@ module.exports = {
   },
   props: {
     /**
+     * Decide whether to filter the results based on search query.
+     * Useful for async filtering, where we search through more complex data.
+     * @type {Boolean}
+     */
+    localSearch: {
+      type: Boolean,
+      default: true
+    },
+    /**
      * Array of available options: Objects, Strings or Integers.
      * If array of objects, visible label will default to option.label.
      * If `labal` prop is passed, label will equal option['label']
@@ -176,9 +185,11 @@ module.exports = {
       let options = this.hideSelected
         ? this.options.filter(this.isNotSelected)
         : this.options
-      options = this.label
-        ? options.filter((option) => option[this.label].includes(this.search))
-        : options.filter((option) => option.includes(this.search))
+      if (this.localSearch) {
+        options = this.label
+          ? options.filter((option) => option[this.label].includes(this.search))
+          : options.filter((option) => option.includes(this.search))
+      }
       if (this.taggable && search.length && !this.isExistingOption(search)) {
         options.unshift({ isTag: true, label: search })
       }

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -51,7 +51,10 @@ module.exports = function (config) {
     browsers: ['PhantomJS'],
     frameworks: ['mocha', 'sinon-chai'],
     reporters: ['spec', 'coverage'],
-    files: ['./index.js'],
+    files: [
+      '../../node_modulOes/phantomjs-polyfill-includes/includes-polyfill.js',
+      './index.js'
+    ],
     preprocessors: {
       './index.js': ['webpack', 'sourcemap']
     },

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -52,7 +52,7 @@ module.exports = function (config) {
     frameworks: ['mocha', 'sinon-chai'],
     reporters: ['spec', 'coverage'],
     files: [
-      '../../node_modulOes/phantomjs-polyfill-includes/includes-polyfill.js',
+      '../../node_modules/phantomjs-polyfill-includes/includes-polyfill.js',
       './index.js'
     ],
     preprocessors: {

--- a/test/unit/specs/Multiselect.spec.js
+++ b/test/unit/specs/Multiselect.spec.js
@@ -1903,6 +1903,22 @@ describe('Multiselect.vue', () => {
       expect(vm.$children[0].filteredOptions).to.deep.equal([{ isTag: true, label: '1' }, 10])
       expect(vm.$children[0].filteredOptions.length).to.equal(2)
     })
+    
+    it('should not alter the available options when :local-search is FALSE', () => {
+      const vm = new Vue({
+        template: '<multiselect :selected="value" :options="source" :multiple="true" :local-search="false"></multiselect>',
+        components: { Multiselect },
+        data: {
+          value: [],
+          source: [10, 20, 30]
+        }
+      }).$mount()
+      expect(vm.$children[0].filteredOptions).to.deep.equal([10, 20, 30])
+      expect(vm.$children[0].filteredOptions.length).to.equal(3)
+      vm.$children[0].search = 'test'
+      expect(vm.$children[0].filteredOptions).to.deep.equal([10, 20, 30])
+      expect(vm.$children[0].filteredOptions.length).to.equal(3)
+    })
   })
 
   describe('#onTag', () => {


### PR DESCRIPTION
Unfortuantly I wasn't able to bundle it

`npm install` works well.  
`npm run build` returns : 
```
> vue-multiselect@2.0.0-beta.2 bundle /home/vagrant/code/boardbang/node_modules/vue-multiselect
> webpack --config build/webpack.bundle.conf.js

Hash: 5a3565ffc27c10c56b9c
Version: webpack 1.13.2
Time: 432ms
                     Asset       Size  Chunks             Chunk Names
    vue-multiselect.min.js    2.28 kB       0  [emitted]  lib
vue-multiselect.min.js.map    2.61 kB       0  [emitted]  lib
           Multiselect.vue    12.6 kB          [emitted]
      MultiselectOption.js  307 bytes          [emitted]
       multiselectMixin.js    11.1 kB          [emitted]
           pointerMixin.js    1.86 kB          [emitted]
                  utils.js  491 bytes          [emitted]
    + 1 hidden modules

ERROR in vue-multiselect.min.js from UglifyJs
SyntaxError: Unexpected token: name (Multiselect) [./src/index.js:6,0]
```

would be great if you could merge it and generate the minified file, so I can use it :) 

Best regards,