### PR TITLE
Add phpStorm '.idea" folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 selenium-debug.log
 test/unit/coverage
 test/e2e/reports
+.idea/


### PR DESCRIPTION
This is just a basic maintenance change to prevent phpStorm IDE config files from being included in a PR by mistake. No consequence to pretty much everybody.