### PR TITLE
Avoid forcing lowercase

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -3,7 +3,7 @@ import deepClone from './utils'
 function includes (str, query) {
   /* istanbul ignore else */
   if (!str) return false
-  const text = str.toString().toLowerCase()
+  const text = str.toString()
   return text.indexOf(query.trim()) !== -1
 }
 


### PR DESCRIPTION
The value entered by the user was [forced in lowercase](https://github.com/monterail/vue-multiselect/blob/2.0/src/multiselectMixin.js#L6).

Allow for the value to remain the same as the user entered it.