### PR TITLE
Option groups need normalized searching too..

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -33,9 +33,11 @@ function flattenOptions (values, label) {
 }
 
 function filterGroups (search, label, values, groupLabel) {
+  const normalizedSearch = search.toString().toLowerCase()
+  
   return (groups) =>
     groups.map(group => {
-      const groupOptions = filterOptions(group[values], search, label)
+      const groupOptions = filterOptions(group[values], normalizedSearch, label)
 
       return groupOptions.length
         ? {


### PR DESCRIPTION
This fixes a bug in 2.0 where case insensitivity does not work with options groups.