### PR TITLE
Fix typo in getting started example

### DIFF
--- a/docs/partials/_getting-started.pug
+++ b/docs/partials/_getting-started.pug
@@ -26,6 +26,7 @@
               &lt;template>
                 &lt;div>
                   &lt;multiselect v-model="value" :options="options">
+                  &lt;/multiselect>
                 &lt;/div>
               &lt;/template>
 


### PR DESCRIPTION
tag <multiselect> has no matching end tag, which results in compile error.