### PR TITLE
Fix active bottom border.

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -357,9 +357,9 @@ fieldset[disabled] .multiselect {
   z-index: 50;
 }
 
-.multiselect--active .multiselect__current,
-.multiselect--active .multiselect__input,
-.multiselect--active .multiselect__tags {
+.multiselect--active:not(.multiselect--above) .multiselect__current,
+.multiselect--active:not(.multiselect--above) .multiselect__input,
+.multiselect--active:not(.multiselect--above) .multiselect__tags {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }


### PR DESCRIPTION
Hi, thanks for making and maintaining this component!

I noticed that the border bottom becomes squared when showing the dropdown above the select. You can check any example in your demos. This should fix it :+1: 

:spock_vue: