### PR TITLE
Fix bug about the display of dropdown list when click on scrollbar in IE11

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -60,6 +60,7 @@
         <div
           class="multiselect__content-wrapper"
           v-show="isOpen"
+          @focus="activate()"
           @mousedown.prevent
           :style="{ maxHeight: optimizedHeight + 'px' }"
           ref="list">


### PR DESCRIPTION
![bug-when-mousedown-ie11](https://user-images.githubusercontent.com/31426828/29807629-fe1759de-8cbe-11e7-8e26-285cafdc942c.gif)

In IE 11, when you clicking on any part of scroll bar then the display behavior of list is interrupted or incorrect. Detail about that as the below image. I have fixed on this PR. If you have another workaround, please apply to fix that. Thanks.