### PR TITLE
Fix component declaration in Getting Started guide

### DIFF
--- a/docs/partials/_getting-started.pug
+++ b/docs/partials/_getting-started.pug
@@ -33,7 +33,7 @@
                 import Multiselect from 'vue-multiselect'
 
                 // register globally
-                Vue.component(Multiselect)
+                Vue.component('multiselect', Multiselect)
 
                 export default {
                   // OR register locally


### PR DESCRIPTION
```javascript
Vue.component(Multiselect)
```
Does not work. It should be:
```javascript
Vue.component('multiselect', Multiselect)
```