### PR TITLE
Add option to change the tag position

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,17 @@ props: {
     default: 'Press enter to create a tag'
   },
   /**
+   * By default new tags will appear above the search results.
+   * Changing to 'bottom' will revert this behaviour
+   * and will proritize the search results
+   * @default 'top'
+   * @type {String}
+  */
+  tagPosition: {
+    type: String,
+    default: 'top'
+  },
+  /**
    * Number of allowed selected options. No limit if false.
    * @default False
    * @type {Number}

--- a/docs/partials/examples/_examples.pug
+++ b/docs/partials/examples/_examples.pug
@@ -68,6 +68,7 @@
 
       #### Optional configuration flags:
       - `tag-placeholder="Add this as new tag"` – A helper label that will be displayed when highlighting the just typed tag suggestion.
+      - `tag-position="bottom"` – By default the tag position will be set to 'top' and new tags will appear above the search results. Changing the tag positon to 'bottom' will revert this behaviour and will prioritize the search results.
     +example('Tagging')
   +subsection('Custom option template')
     :markdown-it

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -221,6 +221,17 @@ export default {
       default: 'Press enter to create a tag'
     },
     /**
+     * By default new tags will appear above the search results.
+     * Changing to 'bottom' will revert this behaviour
+     * and will proritize the search results
+     * @default 'top'
+     * @type {String}
+    */
+    tagPosition: {
+      type: String,
+      default: 'top'
+    },
+    /**
      * Number of allowed selected options. No limit if 0.
      * @default 0
      * @type {Number}
@@ -314,7 +325,11 @@ export default {
 
       /* istanbul ignore else */
       if (this.taggable && normalizedSearch.length && !this.isExistingOption(normalizedSearch)) {
-        options.unshift({ isTag: true, label: normalizedSearch })
+        if (this.tagPosition === 'bottom') {
+          options.push({ isTag: true, label: normalizedSearch })
+        } else {
+          options.unshift({ isTag: true, label: normalizedSearch })
+        }
       }
 
       return options.slice(0, this.optionsLimit)

--- a/test/unit/specs/Multiselect.spec.js
+++ b/test/unit/specs/Multiselect.spec.js
@@ -2802,9 +2802,66 @@ describe('Multiselect.vue', () => {
       vm.$children[0].search = 'TEST'
       vm.$children[0].select(vm.$children[0].filteredOptions[0])
       expect(vm.$children[0].options.length).to.equal(4)
-      expect(vm.$children[0].options).to.deep.equal(['1', '2', '3', 'TEST'])
+      expect(vm.$children[0].options).to.deep.equal(['1', '2', '3', 'test'])
       expect(vm.$children[0].value.length).to.equal(2)
-      expect(vm.$children[0].value).to.deep.equal(['1', 'TEST'])
+      expect(vm.$children[0].value).to.deep.equal(['1', 'test'])
+    })
+  })
+
+  describe('#onTagPosition', () => {
+    it('should display new tag above search results by default when tag-position is defaulted to \'top\'', () => {
+      const vm = new Vue({
+        render (h) {
+          return h(Multiselect, {
+            props: {
+              value: this.value,
+              options: this.source,
+              label: 'name',
+              trackBy: 'name',
+              searchable: true,
+              taggable: true,
+            }
+          })
+        },
+        components: { Multiselect },
+        data: {
+          value: [],
+          source: [{ name: 'Apple' }, { name: 'Banana' }, { name: 'Orange' }]
+        }
+      }).$mount()
+      const comp = vm.$children[0]
+      expect(comp.filteredOptions).to.deep.equal([{ name: 'Apple' }, { name: 'Banana' }, { name: 'Orange' }])
+      comp.search = 'Ban'
+      expect(comp.filteredOptions).to.deep.equal([{ isTag: true, label: 'ban' }, { name: 'Banana' }])
+    })
+  })
+
+  describe('#onTagPosition', () => {
+    it('should display new tag below search results when tag-position is set to \'bottom\'', () => {
+      const vm = new Vue({
+        render (h) {
+          return h(Multiselect, {
+            props: {
+              value: this.value,
+              options: this.source,
+              label: 'name',
+              trackBy: 'name',
+              searchable: true,
+              taggable: true,
+              tagPosition: 'bottom',
+            }
+          })
+        },
+        components: { Multiselect },
+        data: {
+          value: [],
+          source: [{ name: 'Apple' }, { name: 'Banana' }, { name: 'Orange' }]
+        }
+      }).$mount()
+      const comp = vm.$children[0]
+      expect(comp.filteredOptions).to.deep.equal([{ name: 'Apple' }, { name: 'Banana' }, { name: 'Orange' }])
+      comp.search = 'Ban'
+      expect(comp.filteredOptions).to.deep.equal([{ name: 'Banana' }, { isTag: true, label: 'ban' }])
     })
   })
 

--- a/test/unit/specs/Multiselect.spec.js
+++ b/test/unit/specs/Multiselect.spec.js
@@ -2834,9 +2834,7 @@ describe('Multiselect.vue', () => {
       comp.search = 'Ban'
       expect(comp.filteredOptions).to.deep.equal([{ isTag: true, label: 'ban' }, { name: 'Banana' }])
     })
-  })
 
-  describe('#onTagPosition', () => {
     it('should display new tag below search results when tag-position is set to \'bottom\'', () => {
       const vm = new Vue({
         render (h) {


### PR DESCRIPTION
Added a option to change the tag position of a new tag as default behaviour displays the tag first before search results. Passing `:tag-position="bottom"` will revert this behaviour and will display search results before the new tag which will allow the user to press enter to select a search result if it already exists.

If it's a completely new option then there will be no search results remaining and so the new tag will be highlighted allowing a user to press enter to add the new tag.

For details please see issue - #443 

Let me know if you need me to change anything 👍 

Thanks