### PR TITLE
return true in isEmpty if opt is null

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -2,6 +2,7 @@ import deepClone from './utils'
 
 function isEmpty (opt) {
   if (opt === 0) return false
+  if (opt === null) return true
   if (Array.isArray(opt) && opt.length === 0) return true
   return !opt
 }


### PR DESCRIPTION
Using empty array as empty option in single select is bad (IMO).
Boolean(null) returns false, which is good, in case we want one select depend on other, so we can disable second select if first is empty.

Kind of fixes #568 